### PR TITLE
Added tracking script

### DIFF
--- a/src/partials/head-scripts.hbs
+++ b/src/partials/head-scripts.hbs
@@ -2,4 +2,39 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id={{this}}"></script>
     <script>function gtag(){dataLayer.push(arguments)};window.dataLayer=window.dataLayer||[];gtag('js',new Date());gtag('config','{{this}}')</script>
     {{/with}}
+    {{#with site.keys.enableTracking}}
+    <script type="text/javascript"> var tCPrivacyTagManager = "gtm"; </script>
+    <script>
+        var consent = document.createElement("script");
+        if(window.location.pathname.indexOf("/en/") > -1){
+            // Default is EN Cookie Banner if /en/ in path
+            consent.src = "https://cdn.trustcommander.net/privacy/4616/privacy_v2_27.js";
+        } else {
+            // Default is DE Cookie Banner
+            consent.src = "https://cdn.trustcommander.net/privacy/4616/privacy_v2_9.js";
+        }
+        consent.type = "text/javascript";
+        document.head.appendChild(consent);
+    </script>
+    <!-- Matomo consent with trustcommander -->
+    <script type="text/tc_privacy" data-category="2">
+    console.log('consent provided for Matomo')
+    <!-- Matomo -->
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+    _paq.push(["setCookieDomain", "*.stackable.tech"]);
+    _paq.push(["setDomains", ["*.stackable.tech"]]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://stackable.matomo.cloud/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '2']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src='//cdn.matomo.cloud/stackable.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+    </script>
+    <!-- End Matomo Code -->
+    {{/with}}
     <script>var uiRootPath = '{{{uiRootPath}}}'</script>


### PR DESCRIPTION
Inclusion of the script can be enabled with the `enableTracking` antora playbook key.

part of this ticket: https://github.com/stackabletech/documentation/issues/264