### PR TITLE
Render navbar from site.keys instead of with supplemental UI

### DIFF
--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -3,6 +3,31 @@ site:
   url: http://localhost:5252
   title: Brand Docs
   homeUrl: &home_url /xyz/5.2/index.html
+  keys:
+    navbar:
+      "Home": "/home/stable/index.html"
+      "Getting Started": "/home/stable/getting_started.html"
+      "Concept": "/home/stable/concepts/index.html"
+      "Tutorials": "/home/stable/tutorials/index.html"
+      "stackablectl": "/stackablectl/stable/index.html"
+      "Operators":
+        "Overview": "/home/stable/operators/index.html"
+        "Apache Airflow": "/airflow/stable/index.html"
+        "Apache Druid": "/druid/stable/index.html"
+        "Apache HBase": "/hbase/stable/index.html"
+        "Apache Hadoop HDFS": "/hdfs/stable/index.html"
+        "Apache Hive": "/hive/stable/index.html"
+        "Apache Kafka": "/kafka/stable/index.html"
+        "Apache NiFi": "/nifi/stable/index.html"
+        "Apache Spark on K8S": "/spark-k8s/stable/index.html"
+        "Apache Superset": "/superset/stable/index.html"
+        "Trino": "/trino/stable/index.html"
+        "Apache ZooKeeper": "/zookeeper/stable/index.html"
+        "OpenPolicyAgent": "/opa/stable/index.html"
+        "Commons": "/commons-operator/stable/index.html"
+        "Secret": "/secret-operator/stable/index.html"
+        "Listener": "/listener-operator/stable/index.html"
+      "Contribute": "/home/stable/contributor/index.html"
   components:
   - name: abc
     title: Project ABC

--- a/src/helpers/isString.js
+++ b/src/helpers/isString.js
@@ -1,3 +1,3 @@
 'use strict'
 
-module.exports = (s) => typeof s === "string"
+module.exports = (s) => typeof s === 'string'

--- a/src/helpers/isString.js
+++ b/src/helpers/isString.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (s) => typeof s === "string"

--- a/src/partials/navbar.hbs
+++ b/src/partials/navbar.hbs
@@ -1,0 +1,14 @@
+{{#each site.keys.navbar}}
+  {{#if (isString this)}}
+    <a class="navbar-sub-item" href="{{{ relativize this }}}">{{ @key }}</a>
+  {{else}}
+    <div class="navbar-sub-item drop-down">
+      {{ @key }}
+      <div class="drop-down-content">
+        {{#each this}}
+          <a class="drop-down-item" href="{{{ relativize this }}}">{{ @key }}</a>
+        {{/each}}
+      </div>
+    </div>
+  {{/if}}
+{{/each}}


### PR DESCRIPTION
Allows defining the menu items in the antora playbook as YAML, instead of as a supplemental UI file.

This is nicer to work with on the documentation site, as you only lay out the structure and don't care about CSS classes, and it also eliminates the need for supplemental UI entirely. This also means that the `preview` functionality in the UI repo works again.