### PR TITLE
Added failover to supplemental-ui partial to make preview work again

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -25,7 +25,15 @@
     <nav id="navbar-sub" class="navbar-sub">
       <div class="container">
         {{#> navbar }}
-          navbar.hbs partial not found
+          navbar.hbs partial not found - you're seeing failover content
+          <a class="navbar-sub-item" href="#">Home</a>
+          <div class="navbar-sub-item drop-down">
+              Operators
+              <div class="drop-down-content">
+                  <a class="drop-down-item" href="#">Operator 1</a>
+                  <a class="drop-down-item" href="#">Operator 2</a>
+              </div>
+          </div>
         {{/navbar}}
 
         <a class="arrow" href="javascript:document.querySelector('.navbar-sub').classList.toggle('open')">

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -24,7 +24,9 @@
     </nav>
     <nav id="navbar-sub" class="navbar-sub">
       <div class="container">
-        {{> navbar}}
+        {{#> navbar }}
+          navbar.hbs partial not found
+        {{/navbar}}
 
         <a class="arrow" href="javascript:document.querySelector('.navbar-sub').classList.toggle('open')">
           <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="arrow-right" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z"></path></svg>


### PR DESCRIPTION
The `preview` command didn't work anymore because of the missing `navbar` partial which is supplied by the supplemental UI. This PR adds a failover to the partial import to make the preview render again.

Handlebars documentation: https://handlebarsjs.com/guide/partials.html#partial-blocks