### PR TITLE
Fix for admonitions font break after FontAwesome was added

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -4,6 +4,8 @@
 Welcome to Stackable!
 This documentation gives you an overview of the Stackable Data Platform, how to install and manage it as well as some tutorials.
 
+NOTE: This is a dummy note
+
 ++++
 <br>
 ++++

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -139,6 +139,7 @@
 .doc i.fa {
   hyphens: none;
   font-style: normal;
+  font-family: inherit;
 }
 
 .doc p code,


### PR DESCRIPTION
[Admonitions](https://docs.antora.org/antora/latest/asciidoc/admonitions/) support icons if they are present somehow, but I don't know how to change the generated CSS classes. This CSS change fixes the rendered font for now.

I found something online about how we could potentially actually add icons: https://blog.yuzutech.fr/antora-admonitions-icons/