### PR TITLE
fix: Do not use links that lead to redirects

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -2,8 +2,8 @@
   <nav class="navbar">
     <div class="container">
     <div class="navbar-brand">
-      <a class="navbar-item" href="https://stackable.tech">{{!--site.title--}}<img src="{{{uiRootPath}}}/img/stackable-logo.png"></a>
-      <a class="navbar-item documentation-link" href="{{{or site.url (or siteRootUrl siteRootPath)}}}">Documentation</a>
+      <a class="navbar-item" href="https://stackable.tech/en/">{{!--site.title--}}<img src="{{{uiRootPath}}}/img/stackable-logo.png"></a>
+      <a class="navbar-item documentation-link" href="{{{or site.homeUrl site.url}}}">Documentation</a>
       {{#if env.SITE_SEARCH_PROVIDER}}
       <div class="navbar-item search hide-for-print">
         <div id="search-field" class="field">
@@ -16,7 +16,7 @@
         <span></span>
         <span></span>
       </button>
-      <a href="https://www.stackable.tech/contact/" class="button pull-right">Contact Us</a>
+      <a href="https://www.stackable.tech/en/contact/" class="button pull-right">Contact Us</a>
     </div>
       <div id="topbar-nav" class="navbar-menu">
       </div>


### PR DESCRIPTION
Test locally.

This fixes the links to the main page, by linking directly to the /en/ version.

The self-link is also fixed by linking directly to the home url (home/stable/index.html) instead of to docs.stackable.tech.

The idea is that not linking to the redirects will help with SEO