### PR TITLE
Feat/better titles

### DIFF
--- a/src/partials/head-title.hbs
+++ b/src/partials/head-title.hbs
@@ -1,1 +1,2 @@
-    <title>{{{detag (or page.title defaultPageTitle)}}}{{#with site.title}} :: {{this}}{{/with}}</title>
+    <title>{{{detag (or page.title defaultPageTitle)}}}{{#if (ne page.component.name 'home')}} :: {{page.component.title}}{{/if}}{{#with site.title}} :: {{this}}{{/with}}</title>
+    <!-- <title>{{{detag (or page.title defaultPageTitle)}}}{{#if (ne site.component.name 'home')}} :: {{site.component.name}}{{/if}}{{#with site.title}} :: {{this}}{{/with}}</title> -->

--- a/src/partials/head-title.hbs
+++ b/src/partials/head-title.hbs
@@ -1,2 +1,2 @@
-    <title>{{{detag (or page.title defaultPageTitle)}}}{{#if (ne page.component.name 'home')}} :: {{page.component.title}}{{/if}}{{#with site.title}} :: {{this}}{{/with}}</title>
+    <title>{{{detag (or page.title defaultPageTitle)}}}{{#if (ne page.module 'ROOT')}} :: {{page.module}}{{/if}}{{#if (ne page.component.name 'home')}} :: {{page.component.title}}{{/if}}{{#with site.title}} :: {{this}}{{/with}}</title>
     <!-- <title>{{{detag (or page.title defaultPageTitle)}}}{{#if (ne site.component.name 'home')}} :: {{site.component.name}}{{/if}}{{#with site.title}} :: {{this}}{{/with}}</title> -->


### PR DESCRIPTION
closes #37 

I've added the module for the 'home' component. So "Installation :: Documetation" will now be "Installation :: druid :: Documentation"

And the component is added for all components that are not home. This is currently just stackablectl.

The titles will make it easier for google to distinguish all the installation pages, because the titles are now unique. It'll also help regular users.