### PR TITLE
Added helper to version links in the menu

### DIFF
--- a/src/helpers/versioned.js
+++ b/src/helpers/versioned.js
@@ -1,0 +1,18 @@
+// A helper to generate the correct link stub from the current page.
+// if we're already in the same component, generate a link that links to the same version too.
+// targetComponentName: string - name of the component where to link to
+// pageInfo: Object - the 'page' template object: https://docs.antora.org/antora-ui-default/templates/#template-variables
+// path: string - the rest of the link path, inside the target component
+module.exports = (targetComponentName, pageInfo, path) => {
+  // if either the current page is not part of the component or of a different component
+  // or of the same component with the latest version, link to the component and to 'stable', 
+  // the latest version
+  if ((pageInfo.component === undefined) ||
+      (targetComponentName !== pageInfo.component.name) ||
+      (pageInfo.version === pageInfo.component.latest.version)) {
+    return '/' + targetComponentName + '/stable/' + path
+  // otherwise, link to the current version.
+  } else {
+    return '/' + targetComponentName + '/' + pageInfo.version + '/' + path
+  }
+}

--- a/src/helpers/versioned.js
+++ b/src/helpers/versioned.js
@@ -1,11 +1,11 @@
 // A helper to generate the correct link stub from the current page.
 // if we're already in the same component, generate a link that links to the same version too.
 // targetComponentName: string - name of the component where to link to
-// pageInfo: Object - the 'page' template object: https://docs.antora.org/antora-ui-default/templates/#template-variables
+// pageInfo: Object - the 'page' template object: https://docs.antora.org/antora-ui-default/templates
 // path: string - the rest of the link path, inside the target component
 module.exports = (targetComponentName, pageInfo, path) => {
   // if either the current page is not part of the component or of a different component
-  // or of the same component with the latest version, link to the component and to 'stable', 
+  // or of the same component with the latest version, link to the component and to 'stable',
   // the latest version
   if ((pageInfo.component === undefined) ||
       (targetComponentName !== pageInfo.component.name) ||


### PR DESCRIPTION
This is to fix this: https://github.com/stackabletech/documentation/issues/364

Currently, the links in the top menu always link to the latest stable version. This is annoying and unexpected to the user, the links should stay within the version currently selected.

This function allows to make links like this:

    <a class="drop-down-item" href="{{{ relativize (versioned "home" page "hive/index.html") }}}">Apache Hive</a>

so the link gets versioned automatically to the correct version of possible.