### PR TITLE
feat: Add a warning banner for end-of-life versions

### DIFF
--- a/src/css/end-of-life-banner.css
+++ b/src/css/end-of-life-banner.css
@@ -1,7 +1,11 @@
-.unmaintained-version-banner {
+.end-of-life-banner {
   background-color: #f2ce6b;
   border-radius: 0.25rem;
   border: 2px solid #e09807;
   padding: 0.75rem;
   margin-top: calc(var(--toolbar-height) + 0.75rem);
+}
+
+.end-of-life-banner h4 {
+  margin: 0;
 }

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -18,4 +18,5 @@
 @import "print.css";
 @import "landing.css";
 @import "admonition.css";
+@import "warning-banner.css";
 @import "vendor/fontawesome.css";

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -18,5 +18,5 @@
 @import "print.css";
 @import "landing.css";
 @import "admonition.css";
-@import "warning-banner.css";
+@import "end-of-life-banner.css";
 @import "vendor/fontawesome.css";

--- a/src/css/warning-banner.css
+++ b/src/css/warning-banner.css
@@ -1,0 +1,7 @@
+.unmaintained-version-banner {
+  background-color: orange;
+  border-radius: 8px;
+  border: 2px solid darkorange;
+  padding: 10px;
+  margin-top: 50px;  /** adjust based on toolbar height + x */
+}

--- a/src/css/warning-banner.css
+++ b/src/css/warning-banner.css
@@ -1,7 +1,7 @@
 .unmaintained-version-banner {
-  background-color: orange;
-  border-radius: 8px;
-  border: 2px solid darkorange;
-  padding: 10px;
-  margin-top: 50px;  /** adjust based on toolbar height + x */
+  background-color: #f2ce6b;
+  border-radius: 0.25rem;
+  border: 2px solid #e09807;
+  padding: 0.75rem;
+  margin-top: calc(var(--toolbar-height) + 0.75rem);
 }

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -2,7 +2,8 @@
 {{! In antora.yml set asciidoc.attributes.page-end-of-life to true/false}}
 {{#if page.attributes.end-of-life}}
 <div class="unmaintained-version-banner">
-  This version of the Stackable Data Platform is no longer maintained.
+  <b>This version of the Stackable Data Platform is no longer maintained.</b>
+  <br>
   {{#if page.canonicalUrl}}
   Please read the <a href="{{{page.canonicalUrl}}}">latest version of this page</a> instead.
   {{/if}}

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -1,13 +1,14 @@
 <article class="doc">
 {{! In antora.yml set asciidoc.attributes.page-end-of-life to true/false}}
 {{#if page.attributes.end-of-life}}
-<div class="unmaintained-version-banner">
-  <b>This version of the Stackable Data Platform is no longer maintained.</b>
-  <br>
+<aside class="end-of-life-banner">
+  <h4>This version of the Stackable Data Platform is no longer maintained.</h4>
   {{#if page.canonicalUrl}}
-  Please read the <a href="{{{page.canonicalUrl}}}">latest version of this page</a> instead.
+  <p>
+    Please read the <a href="{{{page.canonicalUrl}}}">latest version of this page</a> instead.
+  </p>
   {{/if}}
-</div>
+</aside>
 {{/if}}
 {{#with page.title}}
 <h1 class="page">{{{this}}}</h1>

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -1,4 +1,13 @@
 <article class="doc">
+{{! In antora.yml set asciidoc.attributes.page-end-of-life to true/false}}
+{{#if page.attributes.end-of-life}}
+<div class="unmaintained-version-banner">
+  This version of the Stackable Data Platform is no longer maintained.
+  {{#if page.canonicalUrl}}
+  Please read the <a href="{{{page.canonicalUrl}}}">latest version of this page</a> instead.
+  {{/if}}
+</div>
+{{/if}}
 {{#with page.title}}
 <h1 class="page">{{{this}}}</h1>
 {{/with}}


### PR DESCRIPTION
This PR adds a warning to the top of articles if a version is selected that is no longer maintained. This requires the `asciidoc.attributes.page-end-of-life` variable to be set to true in the `antora.yml` file. If it isn't set, not banner is displayed (this means that this change will not have any effect unless the variable is set).

The banner styling is done with the `unmaintained-version-banner` CSS class.

This is what the banner currently looks like: 

![image](https://github.com/stackabletech/documentation-ui/assets/5787489/f50bb2f4-448f-49f1-9293-54c18fadc06e)


## Example antora.yml config snippet:

```yaml
asciidoc:
  attributes:
    # Whether this version is already end of life. 
    # If true, a banner will be displayed informing the user.
    end-of-life: true
    # to make attributes accessible to the UI template, they need to
    # be prefixed with "page-"
    page-end-of-life: "{end-of-life}"
```