### PR TITLE
feat: add link-bar CSS utilities

### DIFF
--- a/src/css/link-bar.css
+++ b/src/css/link-bar.css
@@ -1,0 +1,29 @@
+/**
+ * CSS styles for a link bar. A list of links, usually at the beginning of a document,
+ * that looks somewhat like a menu. It's useful to provide links to external pages.
+ * Asciidoc example:
+ *
+ * >[.link-bar]
+ * >  * https://github.com/[GitHub]
+ * >  * https://airflow.apache.org/[Airflow]
+ * >  * https://druid.apache.org/[Druid]
+ */
+
+.ulist.link-bar {
+  background-color: #1880bd1f;
+  padding: 0.75rem;
+  border-radius: 0.25rem;
+}
+
+.ulist.link-bar ul {
+  list-style-type: none;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: baseline;
+  margin: 0;
+  padding: 0;
+}
+
+.ulist.link-bar ul li {
+  margin: 0;
+}

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -19,5 +19,5 @@
 @import "landing.css";
 @import "admonition.css";
 @import "end-of-life-banner.css";
-@import "text-utils.css";
+@import "link-bar.css";
 @import "vendor/fontawesome.css";

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -19,4 +19,5 @@
 @import "landing.css";
 @import "admonition.css";
 @import "end-of-life-banner.css";
+@import "text-utils.css";
 @import "vendor/fontawesome.css";

--- a/src/css/text-utils.css
+++ b/src/css/text-utils.css
@@ -1,3 +1,0 @@
-.text-center {
-  text-align: center;
-}

--- a/src/css/text-utils.css
+++ b/src/css/text-utils.css
@@ -1,0 +1,3 @@
+.text-center {
+  text-align: center;
+}


### PR DESCRIPTION
Asciidoc example:

```adoc
[.link-bar]
* {github}[GitHub {external-link-icon}^]
* {feature-tracker}[Feature Tracker {external-link-icon}^]
* {crd}[CRD documentation {external-link-icon}^]
```

![image](https://github.com/stackabletech/documentation-ui/assets/5787489/004a628d-39c9-479c-81d4-d50328f63432)
