### PR TITLE
chore: Enlargen max-width to 1920px

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -122,8 +122,9 @@ body ::-webkit-scrollbar-thumb {
   display: flex;
   position: relative;
   width: 100%;
-  /* I've payed the full screen, I'm going to use the full screen :) */
-  /* max-width: 1280px; */
+  /* We couldn't agree if we want this or not. So we settled on trying 1920px for now */
+  /* See https://github.com/stackabletech/documentation-ui/pull/78 for details */
+  max-width: 1920px;
   margin: 0 auto;
 }
 

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -122,7 +122,8 @@ body ::-webkit-scrollbar-thumb {
   display: flex;
   position: relative;
   width: 100%;
-  max-width: 1280px;
+  /* I've payed the full screen, I'm going to use the full screen :) */
+  /* max-width: 1280px; */
   margin: 0 auto;
 }
 


### PR DESCRIPTION
This popped up in https://github.com/stackabletech/nifi-operator/pull/753#discussion_r1961374589
Relevant Slack discussion: https://stackable-workspace.slack.com/archives/C02LP2HLM9Q/p1740128583523509

This uncovers a bigger problem: The site currently is not responsive, the left and right side of the screen are just white, thus wasted space:
![image](https://github.com/user-attachments/assets/bbd0dd8f-549d-494c-98e3-4751e64fa171)

Often times we have content we can not control the size of (e.g. `stackablectl stacklet list` output, some log messages, snippets of a Python script). It also feels a bit silly that the actual content only takes up +- 50% of the screen (depending on the Window size).

I therefore propose to remove the artificial width limit and let the users decide on the width... well by resizing the window to whatever width they prefer. Zooming in and out suddenly also starts working :exploding_head: 

**Before on a half(!) of the 21/9 screen**
![image](https://github.com/user-attachments/assets/8537f8b8-ee4d-4395-8179-1f2466d3e82a)
**After**
**You can now zoom out if needed!**
![image](https://github.com/user-attachments/assets/672832be-da1a-4392-8656-63ba0523cac7)
