### PR TITLE
chore: Adjust headline sizes

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -76,6 +76,28 @@
   font-weight: var(--alt-heading-font-weight);
 }
 
+/* Custom font sizes, because h4 and down were getting really small */
+
+.doc h2 {
+  font-size: 1.7rem;
+}
+
+.doc h3 {
+  font-size: 1.5rem;
+}
+
+.doc h4 {
+  font-size: 1.3rem;
+}
+
+.doc h5 {
+  font-size: 1.1rem;
+}
+
+.doc h6 {
+  font-size: 0.9rem;
+}
+
 .doc h1 code,
 .doc h2 code,
 .doc h3 code,


### PR DESCRIPTION
h4 and below were becoming really small, even smaller than the normal paragraphs. This commit adds a linear scale from h2 to h6.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/e145bc98-5fee-4b19-b3fb-08a6b01cc965) | ![image](https://github.com/user-attachments/assets/5532c231-fcac-4c81-a9a5-6b84b38e3f2e) |