### PR TITLE
chore: Set max-width to 1480px

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -129,7 +129,7 @@ body ::-webkit-scrollbar-thumb {
 
     See
     - https://github.com/stackabletech/documentation-ui/pull/78
-    - ...
+    - https://github.com/stackabletech/documentation-ui/pull/132
   */
   max-width: 1480px;
   margin: 0 auto;

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -122,7 +122,7 @@ body ::-webkit-scrollbar-thumb {
   display: flex;
   position: relative;
   width: 100%;
-  /* 
+  /*
     We couldn't agree if we want this or not.
     We tried 1920px, it was way to wide, so it got dropped back to 1480px,
     which is should be a good middle ground between 1280px and 1920px.

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -122,9 +122,16 @@ body ::-webkit-scrollbar-thumb {
   display: flex;
   position: relative;
   width: 100%;
-  /* We couldn't agree if we want this or not. So we settled on trying 1920px for now */
-  /* See https://github.com/stackabletech/documentation-ui/pull/78 for details */
-  max-width: 1920px;
+  /* 
+    We couldn't agree if we want this or not.
+    We tried 1920px, it was way to wide, so it got dropped back to 1480px,
+    which is should be a good middle ground between 1280px and 1920px.
+
+    See
+    - https://github.com/stackabletech/documentation-ui/pull/78
+    - ...
+  */
+  max-width: 1480px;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
This drops the max-width to 1480px instead of 1920px, which is way to wide and makes content very hard to read.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/5aee826a-d9c7-4073-af8b-b503968d73ee) |  ![image](https://github.com/user-attachments/assets/089efbb6-05c1-4a59-a541-3ba032014e7f) |

