### PR TITLE
fix: separate loading of mermaid scripts

### DIFF
--- a/src/partials/head.hbs
+++ b/src/partials/head.hbs
@@ -4,4 +4,5 @@
 {{> head-styles}}
 {{> head-meta}}
 {{> head-scripts}}
+{{> mermaid-scripts}}
 {{> head-icons}}


### PR DESCRIPTION
MermaidJS was not loaded, because https://github.com/stackabletech/documentation-ui/pull/139 removed `header-scripts` and the Mermaid extension is loaded in the `header-scripts` template by default. We could change `script_stem` to `head-scripts` (what we use) but the Mermaid extension seems to remove all scripts in that section instead of just appending the Mermaid script.
So I added loading of a separate `mermaid-scripts` partial in `head.hbs` and configured the `script_stem` in the extension configuration in this PR: https://github.com/stackabletech/documentation/pull/796