### PR TITLE
chore: Temporarily disable Matomo

### DIFF
--- a/src/partials/head-scripts.hbs
+++ b/src/partials/head-scripts.hbs
@@ -1,6 +1,8 @@
     {{#with site.keys.enableTracking}}
+    <!-- Temporarily disable Matomo to not run into usage limits due to some kind of DDoS-->
+    <!--
     <script>
-    <!-- Matomo -->
+    // Matomo
     var _paq = window._paq = window._paq || [];
     /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
     _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
@@ -15,8 +17,9 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.async=true; g.src='//cdn.matomo.cloud/stackable.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
     })();
+    // End Matomo Code
     </script>
-    <!-- End Matomo Code -->
+    -->
     {{/with}}
     <script>var uiRootPath = '{{{uiRootPath}}}'</script>
     <script src="/pagefind/pagefind-modular-ui.js"></script>


### PR DESCRIPTION
We do this to not run into usage limits due to some kind of DDoS attack against our docs page.