### PR TITLE
docs: Add archive note

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,15 @@
 = Stackable UI based on Antora Default UI
+
+[IMPORTANT]
+====
+*This repository is archived.* The UI was vendored into the
+https://github.com/stackabletech/documentation[documentation repository]
+(`ui/` directory) with
+https://github.com/stackabletech/documentation/pull/873[documentation#873];
+UI changes are normal pull requests there now, no submodule bump needed.
+This repository stays around read-only so its history remains browsable.
+====
+
 // Settings:
 :experimental:
 :hide-uri-scheme:


### PR DESCRIPTION
The UI was vendored into the documentation repository (`ui/` directory) with stackabletech/documentation#873 - UI changes are normal PRs there now. This note points future readers there; once this PR is merged, the repository gets archived (read-only, history stays browsable).

Pre-archive check: the only external references to this repository are documentation's AGENTS.md/contributor docs (cleanup PR is open in that repo) and `stackable-utils/renovate/config.js`, which lists this repo for Renovate - harmless once archived, but worth removing from that list at some point.